### PR TITLE
feat: support auxiliary clicks

### DIFF
--- a/.changeset/flat-coins-unite.md
+++ b/.changeset/flat-coins-unite.md
@@ -1,0 +1,5 @@
+---
+"@timhettler/radix-card": minor
+---
+
+Support auxiliary clicks, i.e. clicking with the middle mouse button to open the link in a new tab

--- a/lib/src/Card.tsx
+++ b/lib/src/Card.tsx
@@ -33,12 +33,18 @@ interface CardProps extends PrimitiveDivProps {}
 const Card = React.forwardRef<CardElement, CardProps>(
   (props: ScopedProps<CardProps>, forwardedRef) => {
     const { __scopeCard, ...cardProps } = props;
-    const { targetRef, handleRedundantClick } = useRedundantClick();
+    const { targetRef, handleRedundantClick, handleAuxiliaryClick } =
+      useRedundantClick();
     const [targetHasFocus, setTargetHasFocus] = React.useState<"" | null>(null);
 
     const handleClick = composeEventHandlers(
       props.onClick,
       handleRedundantClick
+    );
+
+    const handleAuxClick = composeEventHandlers(
+      props.onAuxClick,
+      handleAuxiliaryClick
     );
 
     const handleFocus = composeEventHandlers(props.onFocus, (event) => {
@@ -59,6 +65,7 @@ const Card = React.forwardRef<CardElement, CardProps>(
           {...cardProps}
           ref={forwardedRef}
           onClick={handleClick}
+          onAuxClick={handleAuxClick}
           onFocus={handleFocus}
           onBlur={handleBlur}
           data-target-focused={targetHasFocus}

--- a/lib/src/useRedundantClick.ts
+++ b/lib/src/useRedundantClick.ts
@@ -38,9 +38,19 @@ const useRedundantClick = <T extends HTMLElement = HTMLElement>() => {
     targetRef.current.dispatchEvent(newEvent);
   };
 
+  // Add to the container element
+  const handleAuxiliaryClick = (event: React.MouseEvent) => {
+    if (event.button !== 1) {
+      return;
+    }
+
+    handleRedundantClick(event);
+  };
+
   return {
     targetRef,
     handleRedundantClick,
+    handleAuxiliaryClick,
   };
 };
 


### PR DESCRIPTION
Hi Tim,

A colleague of mine noticed that the card component (which we're using heavily in our projects, thanks again!) doesn't support auxiliary clicks, i.e clicking with the middle mouse button or scroll wheel to open in a new tab.

This PR fixes this using `onAuxClick`.

I added this to the existing `useRedundantClick` hook; I guess the alternative would be to create a separete hook, but that hook would need to be passed the `targetRef` from `useRedundantClick` in order to work, so I opted for the simpler route of doing both events in the same hook. Let me know if you'd prefer the other option and I can adjust this PR accordingly. 😊 