### PR TITLE
fix: aria described by sometimes returning stale 'undefined' value

### DIFF
--- a/.changeset/fix-card-target-aria-describedby.md
+++ b/.changeset/fix-card-target-aria-describedby.md
@@ -1,0 +1,5 @@
+---
+"@timhettler/radix-card": patch
+---
+
+Fix `Card.Target` `aria-describedby` returning a stale/dangling value. The description id is now coordinated through `Card.Root` state, so `aria-describedby` is only set when a `Card.TargetDescription` is actually rendered and correctly matches a custom `id` when one is provided.

--- a/lib/src/Card.tsx
+++ b/lib/src/Card.tsx
@@ -35,15 +35,16 @@ const Card = React.forwardRef<CardElement, CardProps>(
     const { targetRef, handleRedundantClick, handleAuxiliaryClick } =
       useRedundantClick();
     const [targetHasFocus, setTargetHasFocus] = React.useState<"" | null>(null);
+    const generatedDescriptionId = React.useId();
 
     const handleClick = composeEventHandlers(
       props.onClick,
-      handleRedundantClick
+      handleRedundantClick,
     );
 
     const handleAuxClick = composeEventHandlers(
       props.onAuxClick,
-      handleAuxiliaryClick
+      handleAuxiliaryClick,
     );
 
     const handleFocus = composeEventHandlers(props.onFocus, (event) => {
@@ -58,7 +59,7 @@ const Card = React.forwardRef<CardElement, CardProps>(
       <CardProvider
         scope={__scopeCard}
         targetRef={targetRef}
-        descriptionId={undefined}
+        descriptionId={generatedDescriptionId}
       >
         <Primitive.div
           {...cardProps}
@@ -71,7 +72,7 @@ const Card = React.forwardRef<CardElement, CardProps>(
         />
       </CardProvider>
     );
-  }
+  },
 );
 
 Card.displayName = CARD_NAME;
@@ -99,7 +100,7 @@ const CardTarget = React.forwardRef<CardTargetElement, CardTargetProps>(
         ref={composedRefs}
       />
     );
-  }
+  },
 );
 
 CardTarget.displayName = TARGET_NAME;
@@ -117,15 +118,13 @@ const CardTargetDescription = React.forwardRef<
   CardTargetDescriptionElement,
   CardTargetDescriptionProps
 >((props: ScopedProps<CardTargetDescriptionProps>, forwardedRef) => {
-  const generatedId = React.useId();
   const { __scopeCard, ...targetProps } = props;
   const context = useCardContext(TARGET_DESCRIPTION_NAME, __scopeCard);
-  context.descriptionId = props.id || generatedId;
 
   return (
     <Primitive.span
       {...targetProps}
-      id={context.descriptionId}
+      id={props.id ?? context.descriptionId}
       aria-hidden="true"
       ref={forwardedRef}
     />
@@ -151,7 +150,7 @@ const CardExclude = React.forwardRef<CardExcludeElement, CardExcludeProps>(
     return (
       <Primitive.div data-exclude="" {...targetProps} ref={forwardedRef} />
     );
-  }
+  },
 );
 
 CardExclude.displayName = EXCLUDE_NAME;

--- a/lib/src/Card.tsx
+++ b/lib/src/Card.tsx
@@ -20,6 +20,7 @@ const [createCardContext, createCardScope] = createContextScope(CARD_NAME);
 type CardContextValue = {
   targetRef: React.RefObject<HTMLElement | null>;
   descriptionId?: string;
+  onDescriptionIdChange(id: string | undefined): void;
 };
 
 const [CardProvider, useCardContext] =
@@ -35,7 +36,7 @@ const Card = React.forwardRef<CardElement, CardProps>(
     const { targetRef, handleRedundantClick, handleAuxiliaryClick } =
       useRedundantClick();
     const [targetHasFocus, setTargetHasFocus] = React.useState<"" | null>(null);
-    const generatedDescriptionId = React.useId();
+    const [descriptionId, setDescriptionId] = React.useState<string>();
 
     const handleClick = composeEventHandlers(
       props.onClick,
@@ -59,7 +60,8 @@ const Card = React.forwardRef<CardElement, CardProps>(
       <CardProvider
         scope={__scopeCard}
         targetRef={targetRef}
-        descriptionId={generatedDescriptionId}
+        descriptionId={descriptionId}
+        onDescriptionIdChange={setDescriptionId}
       >
         <Primitive.div
           {...cardProps}
@@ -118,13 +120,21 @@ const CardTargetDescription = React.forwardRef<
   CardTargetDescriptionElement,
   CardTargetDescriptionProps
 >((props: ScopedProps<CardTargetDescriptionProps>, forwardedRef) => {
+  const generatedId = React.useId();
   const { __scopeCard, ...targetProps } = props;
   const context = useCardContext(TARGET_DESCRIPTION_NAME, __scopeCard);
+  const id = props.id ?? generatedId;
+
+  const { onDescriptionIdChange } = context;
+  React.useEffect(() => {
+    onDescriptionIdChange(id);
+    return () => onDescriptionIdChange(undefined);
+  }, [id, onDescriptionIdChange]);
 
   return (
     <Primitive.span
       {...targetProps}
-      id={props.id ?? context.descriptionId}
+      id={id}
       aria-hidden="true"
       ref={forwardedRef}
     />


### PR DESCRIPTION
Fixes a bug in which the `Card.Target` is returning `undefined` for `aria-describedby`, causing screen readers not to read the additional description.
I'm not sure in exactly what cases this is happening. You can confirm in on our project by just removing the temporary patch I added that this is happening for a(some) certain component(s).

The issue:
- directly mutating the shared context object during render.

The fix:
Move `React.useId()` up to `Card.Root` so the ID is part of the context from the very first render — no mutation needed.