### PR TITLE
ci: complete and harden the release + CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Smoke Tests
@@ -20,12 +23,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,20 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: ".nvmrc"
-          cache: yarn
 
       - name: Install Dependencies
         run: yarn
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           publish: yarn release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,11 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
+        with:
+          publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "build": "turbo build",
+    "release": "turbo run build --filter=@timhettler/radix-card && changeset publish",
     "publish-packages": "turbo run build lint && changeset version && changeset publish"
   },
   "name": "radix-card"


### PR DESCRIPTION
## What this does
Makes the **Release** workflow work end-to-end (open the version PR, then publish to npm) **and** applies the low-risk supply-chain hardening from the [npm release-security review](https://evilmartians.com/chronicles/the-secure-way-to-release-an-npm-package). It's one PR because everything touches the two workflow files (separate PRs would conflict).

### 1. Fix the failing workflow (permissions)
The Release workflow was failing on every push to `main` with a 403 pushing the release branch — the default `GITHUB_TOKEN` is read-only and the job had no `permissions:` block. Added job-scoped least-privilege `contents: write` + `pull-requests: write`.

### 2. Wire npm publishing
- New root script `release`: `turbo run build --filter=@timhettler/radix-card && changeset publish`.
- `changesets/action` gets `publish: yarn release` and npm auth via `NPM_TOKEN` / `YARN_NPM_AUTH_TOKEN` (Yarn 4 reads the latter for `yarn npm publish`).

### 3. Security hardening (quick wins)
- **Pin all actions to commit SHAs** (checkout, setup-node, changesets/action) in both workflows — blocks the mutable-tag hijack vector. Major tags kept as `# v4` comments.
- **`persist-credentials: false`** on both checkouts — keeps `GITHUB_TOKEN` out of `.git/config`, where later steps (including dependency install scripts) could read it. `changesets/action` configures its own git auth, so the release push is unaffected.
- **Drop the yarn cache in the release job** — removes a cache-poisoning path into the one job that holds the npm token. CI keeps its cache (PR smoke tests, lower risk).
- **`permissions: contents: read`** at the top of CI (least privilege).
- **Dependabot for `github-actions`** — so the SHA pins get automatic bump PRs instead of rotting. (Heads up: `setup-node@v3` is now several majors behind — expect a bump PR.)

## ⚠️ Two manual prerequisites (can't be done in code)
1. Enable Settings → Actions → General → **"Allow GitHub Actions to create and approve pull requests."**
2. Add an **`NPM_TOKEN`** repo secret — an npm **automation** token with publish access to `@timhettler/radix-card`.

## Deferred (real redesign, not a quick win — happy to follow up)
- **OIDC trusted publishing + provenance** (drop the static token entirely). `changesets` here publishes via `yarn npm publish`; npm's OIDC/provenance are npm-CLI features, so this likely means changing the publish mechanism.
- **Isolating publish into its own minimal least-privilege job** — doesn't map onto `changesets/action` (one action does the version-PR *or* the publish per run), so it comes with the OIDC redesign.
- Staged publishing (`npm stage publish`) with 2FA approval; workflow linting (zizmor/CodeQL); org 2FA, immutable releases, tag rulesets (repo/org settings).

## Watch on first run
`persist-credentials: false` is new — confirm the first Release run still pushes `changeset-release/main` cleanly (changesets manages its own auth, so it should; trivially revertible if not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
