### PR TITLE
ci: use RELEASE_TOKEN (PAT) for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           publish: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (secret: RELEASE_TOKEN) with `workflows` permission so Changesets
+          # can update the Version PR branch even when it includes workflow-file
+          # changes — the default GITHUB_TOKEN cannot push to .github/workflows/**.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The Release workflow's Changesets step used the default `GITHUB_TOKEN`, which **cannot push changes under `.github/workflows/**`**. Once Dependabot bumped `actions/checkout` / `actions/setup-node` on `main`, Changesets' force-update of the "Version Packages" branch (now containing those workflow edits) was rejected:

> refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission

This points the Changesets step at a fine-grained PAT (`secrets.RELEASE_TOKEN`, with **contents + pull-requests + workflows** write) so it can update the Version PR branch and publish. Changesets uses this env token to authenticate its git push, so no other change is needed — `persist-credentials: false` and everything else stay as-is.

## After merge
The Release workflow will be able to (re)sync the **Version Packages PR (#93)**; merging that PR publishes `1.2.2` to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
